### PR TITLE
zy/103 fix personal settings page

### DIFF
--- a/lib/features/bloc/survey_bloc.dart
+++ b/lib/features/bloc/survey_bloc.dart
@@ -102,7 +102,7 @@ class SurveyBloc extends Bloc<SurveyEvent, SurveyState> {
       };
 
       // Find the first unanswered question.
-      
+
       int startIndex = 0;
       for (var i = 0; i < event.questions.length; i++) {
         if (responses[event.questions[i]] == null) {

--- a/lib/questionnaire/question.dart
+++ b/lib/questionnaire/question.dart
@@ -15,7 +15,7 @@ import 'package:msfatigue/widgets/image/image.dart';
 class QuestionPage extends StatefulWidget {
   /// If non-null, [savedResponses] contains a map of [question -> answer]
   /// to pre-fill the user's answers on load.
-  
+
   final Map<String, String?>? savedResponses;
 
   const QuestionPage({super.key, this.savedResponses});
@@ -54,7 +54,7 @@ class _QuestionPageState extends State<QuestionPage> {
   }
 
   /// Loads the webId from SharedPreferences via the SurveyBloc's instance.
-  
+
   Future<void> _loadWebId() async {
     final prefs = context.read<SurveyBloc>().sharedPreferences;
     setState(() {
@@ -76,7 +76,7 @@ class _QuestionPageState extends State<QuestionPage> {
     if (!mounted) return;
 
     // Initialize survey with saved responses.
-    
+
     context.read<SurveyBloc>().add(InitializeSurvey(
           questions: questions,
           savedResponses: widget.savedResponses,
@@ -231,7 +231,8 @@ class _QuestionPageState extends State<QuestionPage> {
                   return const Center(child: Text("No more questions."));
                 }
 
-                final String currentQuestion = questionKeys[currentQuestionIndex];
+                final String currentQuestion =
+                    questionKeys[currentQuestionIndex];
                 String? selectedResponse = state.responses[currentQuestion];
 
                 // Check if we have a widget.savedResponses & the bloc doesn't yet have an answer.

--- a/lib/widgets/page/personal_settings.dart
+++ b/lib/widgets/page/personal_settings.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:msfatigue/constants/secrets.dart';
+import 'package:msfatigue/questionnaire/welcome_back.dart';
 import 'package:msfatigue/welcome.dart';
 
 class PersonalSettings extends StatefulWidget {
@@ -185,12 +187,31 @@ class _PersonalSettingsState extends State<PersonalSettings> {
                 size: 40,
               ),
               padding: EdgeInsets.zero,
-              onPressed: () => Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const WelcomeScreen(),
-                ),
-              ),
+              onPressed: () async {
+                // Capture the navigator before the async gap.
+
+                final navigator = Navigator.of(context);
+                final prefs = await SharedPreferences.getInstance();
+                if (!mounted) return;
+
+                final username = prefs.getString('msfatigue_username') ?? "";
+                final password = prefs.getString('msfatigue_password') ?? "";
+
+                if (username == expectedUsername &&
+                    password == expectedPassword) {
+                  navigator.pushReplacement(
+                    MaterialPageRoute(
+                      builder: (context) => const WelcomeBackScreen(),
+                    ),
+                  );
+                } else {
+                  navigator.pushReplacement(
+                    MaterialPageRoute(
+                      builder: (context) => const WelcomeScreen(),
+                    ),
+                  );
+                }
+              },
             ),
           ),
         ],


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- FLOW: X from Account Details should return to WELCOME BACK when registration/consent is complete

- Link to associated issue: #103 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-existing lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
